### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04
             python-version: "3.6"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -12,19 +12,23 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/esparto/_options.py
+++ b/esparto/_options.py
@@ -134,9 +134,9 @@ class OutputOptions(yaml.YAMLObject, ConfigMixin):
     esparto_js: str = str(_MODULE_PATH / "resources/js/esparto.js")
     jinja_template: str = str(_MODULE_PATH / "resources/jinja/base.html.jinja")
 
-    matplotlib: MatplotlibOptions = MatplotlibOptions()
-    bokeh: BokehOptions = BokehOptions()
-    plotly: PlotlyOptions = PlotlyOptions()
+    matplotlib: MatplotlibOptions = field(default_factory=MatplotlibOptions)
+    bokeh: BokehOptions = field(default_factory=BokehOptions)
+    plotly: PlotlyOptions = field(default_factory=PlotlyOptions)
 
     _pdf_temp_dir: str = TemporaryDirectory().name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,10 @@ multi_line_output = 3
 max-line-length = 120
 exclude = scratch.py, docs/
 ignore =
-    W503, # line break before binary operator
-    E203, # whitespace before ':'
+    # line break before binary operator
+    W503,
+    # whitespace before ':'
+    E203,
 per-file-ignores =
     __init__.py:E402, F401
     cdnlinks.py:E501


### PR DESCRIPTION
In Python 3.11 the dataclass default mutability check raises ValueError for any unhashable default (https://docs.python.org/3/whatsnew/3.11.html#dataclasses). With default_factory we get unique instances for each OutputOptions.